### PR TITLE
Rename NamespaceReservationServer to AdmissionServer

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -82,8 +82,8 @@ type ExtraConfig struct {
 	AdmissionHooks []AdmissionHook
 }
 
-// NamespaceReservationServer contains state for a Kubernetes cluster master/api server.
-type NamespaceReservationServer struct {
+// AdmissionServer contains state for a Kubernetes cluster master/api server.
+type AdmissionServer struct {
 	GenericAPIServer *genericapiserver.GenericAPIServer
 }
 
@@ -112,14 +112,14 @@ func (c *Config) Complete() CompletedConfig {
 	return CompletedConfig{&completedCfg}
 }
 
-// New returns a new instance of NamespaceReservationServer from the given config.
-func (c completedConfig) New() (*NamespaceReservationServer, error) {
+// New returns a new instance of AdmissionServer from the given config.
+func (c completedConfig) New() (*AdmissionServer, error) {
 	genericServer, err := c.GenericConfig.New("kubernetes-namespace-reservation", genericapiserver.EmptyDelegate) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}
 
-	s := &NamespaceReservationServer{
+	s := &AdmissionServer{
 		GenericAPIServer: genericServer,
 	}
 
@@ -211,7 +211,7 @@ func (c completedConfig) New() (*NamespaceReservationServer, error) {
 }
 
 func postStartHookName(hook AdmissionHook) string {
-	ns := []string{}
+	var ns []string
 	if mutatingHook, ok := hook.(MutatingAdmissionHook); ok {
 		gvr, _ := mutatingHook.MutatingResource()
 		ns = append(ns, fmt.Sprintf("mutating-%s.%s.%s", gvr.Resource, gvr.Version, gvr.Group))

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -21,7 +21,7 @@ type AdmissionHook apiserver.AdmissionHook
 type ValidatingAdmissionHook apiserver.ValidatingAdmissionHook
 type MutatingAdmissionHook apiserver.MutatingAdmissionHook
 
-func RunAdmission(admissionHooks ...AdmissionHook) {
+func RunAdmissionServer(admissionHooks ...AdmissionHook) {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
@@ -31,12 +31,12 @@ func RunAdmission(admissionHooks ...AdmissionHook) {
 
 	stopCh := genericapiserver.SetupSignalHandler()
 
-	// done to avoid cannot use admissionHooks (type []AdmissionHook) as type []apiserver.AdmissionHook in argument to "github.com/openshift/kubernetes-namespace-reservation/pkg/genericadmissionserver/cmd/server".NewCommandStartNamespaceReservationServer
-	castSlice := []apiserver.AdmissionHook{}
+	// done to avoid cannot use admissionHooks (type []AdmissionHook) as type []apiserver.AdmissionHook in argument to "github.com/openshift/kubernetes-namespace-reservation/pkg/genericadmissionserver/cmd/server".NewCommandStartAdmissionServer
+	var castSlice []apiserver.AdmissionHook
 	for i := range admissionHooks {
 		castSlice = append(castSlice, admissionHooks[i])
 	}
-	cmd := server.NewCommandStartNamespaceReservationServer(os.Stdout, os.Stderr, stopCh, castSlice...)
+	cmd := server.NewCommandStartAdmissionServer(os.Stdout, os.Stderr, stopCh, castSlice...)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {
 		glog.Fatal(err)

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -16,7 +16,7 @@ import (
 
 const defaultEtcdPathPrefix = "/registry/online.openshift.io"
 
-type NamespaceReservationServerOptions struct {
+type AdmissionServerOptions struct {
 	RecommendedOptions *genericoptions.RecommendedOptions
 
 	AdmissionHooks []apiserver.AdmissionHook
@@ -25,8 +25,8 @@ type NamespaceReservationServerOptions struct {
 	StdErr io.Writer
 }
 
-func NewNamespaceReservationServerOptions(out, errOut io.Writer, admissionHooks ...apiserver.AdmissionHook) *NamespaceReservationServerOptions {
-	o := &NamespaceReservationServerOptions{
+func NewAdmissionServerOptions(out, errOut io.Writer, admissionHooks ...apiserver.AdmissionHook) *AdmissionServerOptions {
+	o := &AdmissionServerOptions{
 		// TODO we will nil out the etcd storage options.  This requires a later level of k8s.io/apiserver
 		RecommendedOptions: genericoptions.NewRecommendedOptions(defaultEtcdPathPrefix, apiserver.Codecs.LegacyCodec(admissionv1beta1.SchemeGroupVersion)),
 
@@ -41,8 +41,8 @@ func NewNamespaceReservationServerOptions(out, errOut io.Writer, admissionHooks 
 }
 
 // NewCommandStartMaster provides a CLI handler for 'start master' command
-func NewCommandStartNamespaceReservationServer(out, errOut io.Writer, stopCh <-chan struct{}, admissionHooks ...apiserver.AdmissionHook) *cobra.Command {
-	o := NewNamespaceReservationServerOptions(out, errOut, admissionHooks...)
+func NewCommandStartAdmissionServer(out, errOut io.Writer, stopCh <-chan struct{}, admissionHooks ...apiserver.AdmissionHook) *cobra.Command {
+	o := NewAdmissionServerOptions(out, errOut, admissionHooks...)
 
 	cmd := &cobra.Command{
 		Short: "Launch a namespace reservation API server",
@@ -54,7 +54,7 @@ func NewCommandStartNamespaceReservationServer(out, errOut io.Writer, stopCh <-c
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunNamespaceReservationServer(stopCh); err != nil {
+			if err := o.RunAdmissionServer(stopCh); err != nil {
 				return err
 			}
 			return nil
@@ -67,15 +67,15 @@ func NewCommandStartNamespaceReservationServer(out, errOut io.Writer, stopCh <-c
 	return cmd
 }
 
-func (o NamespaceReservationServerOptions) Validate(args []string) error {
+func (o AdmissionServerOptions) Validate(args []string) error {
 	return nil
 }
 
-func (o *NamespaceReservationServerOptions) Complete() error {
+func (o *AdmissionServerOptions) Complete() error {
 	return nil
 }
 
-func (o NamespaceReservationServerOptions) Config() (*apiserver.Config, error) {
+func (o AdmissionServerOptions) Config() (*apiserver.Config, error) {
 	// TODO have a "real" external address
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
@@ -95,7 +95,7 @@ func (o NamespaceReservationServerOptions) Config() (*apiserver.Config, error) {
 	return config, nil
 }
 
-func (o NamespaceReservationServerOptions) RunNamespaceReservationServer(stopCh <-chan struct{}) error {
+func (o AdmissionServerOptions) RunAdmissionServer(stopCh <-chan struct{}) error {
 	config, err := o.Config()
 	if err != nil {
 		return err


### PR DESCRIPTION
We would like use this library to implement our own admission controllers. So, I would like to rename `NamespaceReservationServer` to more generic `AdmissionServer` .

If this looks ok, I can send a follow up pr to update https://github.com/openshift/kubernetes-namespace-reservation

cc: @deads2k 