### PR TITLE
Don't add admission/v1beta1 group as a prioritized version

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -130,7 +130,6 @@ func (c completedConfig) New() (*AdmissionServer, error) {
 		// TODO we're going to need a later k8s.io/apiserver so that we can get discovery to list a different group version for
 		// our endpoint which we'll use to back some custom storage which will consume the AdmissionReview type and give back the correct response
 		apiGroupInfo := genericapiserver.APIGroupInfo{
-			PrioritizedVersions :[]schema.GroupVersion{admissionv1beta1.SchemeGroupVersion},
 			VersionedResourcesStorageMap: map[string]map[string]rest.Storage{},
 			// TODO unhardcode this.  It was hardcoded before, but we need to re-evaluate
 			OptionsExternalVersion: &schema.GroupVersion{Version: "v1"},


### PR DESCRIPTION
If multiple webhooks with different groups were added, this caused error like:

`
W0709 12:49:31.199013    4287 genericapiserver.go:319] Skipping API admission.k8s.io/v1beta1 because it has no resources.
[restful] 2018/07/09 12:49:31 log.go:33: [restful] WebService with duplicate root path detected:['&{/apis/admission.k8s.io 0xc420dc63c0 [{GET [application/json application/yaml application/vnd.kubernetes.protobuf] [application/json application/yaml application/vnd.kubernetes.protobuf] /apis/admission.k8s.io/ 0x14a0d50 [] / [apis admission.k8s.io] 0xc420dc6400 get information of a group  getAPIGroup [] map[] <nil> {{ }  [] { } []} map[]}] [] [] [] [] get information of a group  <nil> false {{0 0} 0 0 0 0}}']
`

Please note that it says, **WebService with duplicate root path detected:['&{/apis/admission.k8s.io**